### PR TITLE
Fixed broken image

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -4,7 +4,7 @@
   <p>Want to know more about me?</p>
   <p>
     <picture>
-      <img srcset="http://cdn.kagumba.com/me.svg" type="image/svg+xml" width="400">
+      <img srcset="https://cdn.kagumba.com/hs/me.svg" type="image/svg+xml" width="400">
     </picture>
   </p>
   <p>


### PR DESCRIPTION
#### What does this PR do?

Fixes the about page image.
Forces the image src to be secured (https).
#### Description of Task to be completed?

About page image was broken because of its src.
#### How should this be manually tested?

By visiting the About page `/about`
